### PR TITLE
working resnet18 in pspnet model

### DIFF
--- a/ptsemseg/models/pspnet.py
+++ b/ptsemseg/models/pspnet.py
@@ -33,9 +33,9 @@ class pspnet(nn.Module):
 
         # Decoder
         self.decoder4 = linknetUp(filters[3], filters[2])
-        self.decoder3 = linknetUp(filters[2], filters[1])
-        self.decoder2 = linknetUp(filters[1], filters[0])
-        self.decoder1 = linknetUp(filters[0], filters[0])
+        self.decoder4 = linknetUp(filters[2], filters[1])
+        self.decoder4 = linknetUp(filters[1], filters[0])
+        self.decoder4 = linknetUp(filters[0], filters[0])
 
         # Final Classifier
         self.finaldeconvbnrelu1 = nn.Sequential(nn.ConvTranspose2d(filters[0], 32/feature_scale, 3, 2, 1),

--- a/ptsemseg/models/pspnet.py
+++ b/ptsemseg/models/pspnet.py
@@ -33,9 +33,9 @@ class pspnet(nn.Module):
 
         # Decoder
         self.decoder4 = linknetUp(filters[3], filters[2])
-        self.decoder4 = linknetUp(filters[2], filters[1])
-        self.decoder4 = linknetUp(filters[1], filters[0])
-        self.decoder4 = linknetUp(filters[0], filters[0])
+        self.decoder3 = linknetUp(filters[2], filters[1])
+        self.decoder2 = linknetUp(filters[1], filters[0])
+        self.decoder1 = linknetUp(filters[0], filters[0])
 
         # Final Classifier
         self.finaldeconvbnrelu1 = nn.Sequential(nn.ConvTranspose2d(filters[0], 32/feature_scale, 3, 2, 1),

--- a/ptsemseg/models/utils.py
+++ b/ptsemseg/models/utils.py
@@ -229,13 +229,13 @@ class linknetUp(nn.Module):
         super(linknetUp, self).__init__()
 
         # B, 2C, H, W -> B, C/2, H, W
-        self.convbnrelu1 = conv2DBatchNormRelu(in_channels, n_filters/2, k_size=1, stride=1, padding=1)
+        self.convbnrelu1 = conv2DBatchNormRelu(in_channels, n_filters/2, k_size=1, stride=1, padding=0)
 
-        # B, C/2, H, W -> B, C/2, H, W
-        self.deconvbnrelu2 = nn.deconv2DBatchNormRelu(n_filters/2, n_filters/2, k_size=3,  stride=2, padding=0,)
+        # B, C/2, H, W -> B, C/2, 2H, 2W
+        self.deconvbnrelu2 = deconv2DBatchNormRelu(n_filters/2, n_filters/2, k_size=2,  stride=2, padding=0)
 
-        # B, C/2, H, W -> B, C, H, W
-        self.convbnrelu3 = conv2DBatchNormRelu(n_filters/2, n_filters, k_size=1, stride=1, padding=1)
+        # B, C/2, 2H, 2W -> B, C, 2H, 2W
+        self.convbnrelu3 = conv2DBatchNormRelu(n_filters/2, n_filters, k_size=1, stride=1, padding=0)
 
     def forward(self, x):
         x = self.convbnrelu1(x)


### PR DESCRIPTION
I have further fixed some bugs(which were causing runtime errors in resnet18) as follows:

- removed inline operations like d4+=e3 -> d4= d4+e3
- corrected kernel size, strides and padding for consistent input and output channels.
- fixed some minor typos like variable names etc
- commented line 16 in pspnet.py.  To be honest I was not sure what it does. If you need it you can uncomment it.

Upcoming(next 2 days):
- multiple resnet support: instead of hardcoded resnet18, different resnets can be used. In PSPnet two resnets are used as baseline, resnet 50 and resnet 101 and deeper resnets were inspected for performance improvement.
- optional dialation feature to switch it on and off with the choice of your resnet.
-pyramid pooling module
- auxiliary loss
