### PR TITLE
Add mit scene parsing benchmark loader

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,5 +16,9 @@
   "ade20k":
   {
     "data_path": "/Users/meet/data/ADE20K_2016_07_26/"
+  },
+  "mit_sceneparsing_benchmark":
+  {
+    "data_path": "/home/ubuntu/DATA/ADEChallengeData2016/"
   }
 }

--- a/ptsemseg/loader/__init__.py
+++ b/ptsemseg/loader/__init__.py
@@ -3,15 +3,27 @@ import json
 from ptsemseg.loader.pascal_voc_loader import pascalVOCLoader
 from ptsemseg.loader.camvid_loader import camvidLoader
 from ptsemseg.loader.ade20k_loader import ADE20KLoader
+from ptsemseg.loader.mit_sceneparsing_benchmark_loader import MITSceneParsingBenchmarkLoader
+
 
 def get_loader(name):
+    """get_loader
+
+    :param name:
+    """
     return {
         'pascal': pascalVOCLoader,
         'camvid': camvidLoader,
         'ade20k': ADE20KLoader,
+        'mit_sceneparsing_benchmark': MITSceneParsingBenchmarkLoader,
     }[name]
 
-def get_data_path(name):
-    js = open('config.json').read()
-    data = json.loads(js)
+
+def get_data_path(name, config_file='config.json'):
+    """get_data_path
+
+    :param name:
+    :param config_file:
+    """
+    data = json.load(open(config_file))
     return data[name]['data_path']

--- a/ptsemseg/loader/mit_sceneparsing_benchmark_loader.py
+++ b/ptsemseg/loader/mit_sceneparsing_benchmark_loader.py
@@ -1,0 +1,105 @@
+import os
+import torch
+import numpy as np
+import scipy.misc as m
+
+from torch.utils import data
+
+from ptsemseg.uitls import recursive_glob
+
+
+class MITSceneParsingBenchmarkLoader(data.Dataset):
+    """MITSceneParsingBenchmarkLoader
+
+    http://sceneparsing.csail.mit.edu/
+
+    Data is derived from ADE20k, and can be downloaded from here:
+    http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip
+
+    NOTE: this loader is not designed to work with the original ADE20k dataset;
+    for that you will need the ADE20kLoader
+
+    This class can also be extended to load data for places challenge:
+    https://github.com/CSAILVision/placeschallenge/tree/master/sceneparsing
+
+    """
+    def __init__(self, root, split="training", is_transform=False, img_size=512):
+        """__init__
+
+        :param root:
+        :param split:
+        :param is_transform:
+        :param img_size:
+        """
+        self.root = root
+        self.split = split
+        self.is_transform = is_transform
+        self.n_classes = 151  # 0 is reserved for "other"
+        self.img_size = img_size if isinstance(img_size, tuple) else (img_size, img_size)
+        self.mean = np.array([104.00699, 116.66877, 122.67892])
+        self.files = {}
+
+        self.images_base = os.path.join(self.root, 'images', self.split)
+        self.annotations_base = os.path.join(self.root, 'annotations', self.split)
+
+        self.files[split] = recursive_glob(rootdir=self.images_base, suffix='.jpg')
+
+        if not self.files[split]:
+            raise Exception("No files for split=[%s] found in %s" % (split, self.images_base))
+
+        print("Found %d %s images" % (len(self.files[split]), split))
+
+    def __len__(self):
+        """__len__"""
+        return len(self.files[self.split])
+
+    def __getitem__(self, index):
+        """__getitem__
+
+        :param index:
+        """
+        img_path = self.files[self.split][index].rstrip()
+        lbl_path = os.path.join(self.annotations_base, os.path.basename(img_path)[:-4] + '.png')
+
+        img = m.imread(img_path)
+        img = np.array(img, dtype=np.uint8)
+
+        lbl = m.imread(lbl_path)
+        lbl = np.array(lbl, dtype=np.uint8)
+
+        if self.is_transform:
+            img, lbl = self.transform(img, lbl)
+
+        return img, lbl
+
+    def transform(self, img, lbl):
+        """transform
+
+        :param img:
+        :param lbl:
+        """
+        img = img[:, :, ::-1]
+        img = img.astype(np.float64)
+        img -= self.mean
+        img = m.imresize(img, (self.img_size[0], self.img_size[1]))
+        # Resize scales images from 0 to 255, thus we need
+        # to divide by 255.0
+        img = img.astype(float) / 255.0
+        # NHWC -> NCWH
+        img = img.transpose(2, 0, 1)
+
+        classes = np.unique(lbl)
+        lbl = lbl.astype(float)
+        lbl = m.imresize(lbl, (self.img_size[0], self.img_size[1]), 'nearest', mode='F')
+        lbl = lbl.astype(int)
+
+        if not np.all(classes == np.unique(lbl)):
+            print("WARN: resizing labels yielded fewer classes")
+
+        if not np.all(np.unique(lbl) < self.n_classes):
+            raise ValueError("Segmentation map contained invalid class values")
+
+        img = torch.from_numpy(img).float()
+        lbl = torch.from_numpy(lbl).long()
+
+        return img, lbl


### PR DESCRIPTION
I haven't worked out how to convert the raw ADE20k dataset to the MIT sceneparsing label set, but this loader works with the actual benchmark training dataset (150 classes) directly and trains fine.

Fetch data from:
```
wget http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip
unzip ADEChallengeData2016.zip
```

Edit config to point to the data and run using:
```
python train.py --arch fcn8s --dataset mit_sceneparsing_benchmark
```