### PR TITLE
Resnet encoders

### DIFF
--- a/lr_scheduling.py
+++ b/lr_scheduling.py
@@ -1,0 +1,21 @@
+def poly_lr_scheduler(optimizer, init_lr, iter, lr_decay_iter=1, max_iter=30000, power=0.9,):
+    """Polynomial decay of learning rate
+        :param init_lr is base learning rate
+        :param iter is a current iteration
+        :param lr_decay_iter how frequently decay occurs, default is 1
+        :param max_iter is number of maximum iterations
+        :param power is a polymomial power
+
+    """
+    if iter % lr_decay_iter or iter > max_iter:
+        return optimizer
+
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = init_lr*(1 - iter/max_iter)**power
+
+
+def adjust_learning_rate(optimizer, init_lr, epoch):
+    """Sets the learning rate to the initial LR decayed by 10 every 30 epochs"""
+    lr = init_lr * (0.1 ** (epoch // 30))
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = lr

--- a/ptsemseg/models/pspnet.py
+++ b/ptsemseg/models/pspnet.py
@@ -33,9 +33,9 @@ class pspnet(nn.Module):
 
         # Decoder
         self.decoder4 = linknetUp(filters[3], filters[2])
-        self.decoder3 = linknetUp(filters[2], filters[1])
-        self.decoder2 = linknetUp(filters[1], filters[0])
-        self.decoder1 = linknetUp(filters[0], filters[0])
+        self.decoder4 = linknetUp(filters[2], filters[1])
+        self.decoder4 = linknetUp(filters[1], filters[0])
+        self.decoder4 = linknetUp(filters[0], filters[0])
 
         # Final Classifier
         self.finaldeconvbnrelu1 = nn.Sequential(nn.ConvTranspose2d(filters[0], 32/feature_scale, 3, 2, 1),

--- a/ptsemseg/models/pspnet.py
+++ b/ptsemseg/models/pspnet.py
@@ -2,18 +2,28 @@ import torch.nn as nn
 
 from utils import *
 
+Resnets = {'resnet18' :{'layers':[2, 2, 2, 2],'filters':[64, 128, 256, 512], 'block':residualBlock,'expansion':1},
+           'resnet34' :{'layers':[3, 4, 6, 3],'filters':[64, 128, 256, 512], 'block':residualBlock,'expansion':1},
+           'resnet50' :{'layers':[3, 4, 6, 3],'filters':[64, 128, 256, 512], 'block':residualBottleneck,'expansion':4},
+           'resnet101' :{'layers':[3, 4, 23, 3],'filters':[64, 128, 256, 512], 'block':residualBottleneck,'expansion':4},
+           'resnet152':{'layers':[3, 8, 36, 3],'filters':[64, 128, 256, 512], 'block':residualBottleneck,'expansion':4}
+            }
+
+
 class pspnet(nn.Module):
 
-    def __init__(self, feature_scale=4, n_classes=21, is_deconv=True, in_channels=3, is_batchnorm=True):
+    def __init__(self, resnet='resnet18', feature_scale=4, n_classes=21, is_deconv=True, in_channels=3, is_batchnorm=True):
         super(pspnet, self).__init__()
         self.is_deconv = is_deconv
         self.in_channels = in_channels
         self.is_batchnorm = is_batchnorm
         self.feature_scale = feature_scale
-        self.layers = [2, 2, 2, 2] # Currently hardcoded for ResNet-18
 
-        filters = [64, 128, 256, 512]
+        assert resnet in Resnets.keys(), 'Not a valid resnet, currently supported resnets are 18, 34, 50, 101 and 152'
+        layers = Resnets[resnet]['layers']
+        filters = Resnets[resnet]['filters']
         # filters = [x / self.feature_scale for x in filters]
+        expansion =Resnets[resnet]['expansion']
 
         self.inplanes = filters[0]
 
@@ -23,19 +33,19 @@ class pspnet(nn.Module):
                                                padding=3, stride=2, bias=False)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
 
-        block = residualBlock
-        self.encoder1 = self._make_layer(block, filters[0], self.layers[0])
-        self.encoder2 = self._make_layer(block, filters[1], self.layers[1], stride=2)
-        self.encoder3 = self._make_layer(block, filters[2], self.layers[2], stride=2)
-        self.encoder4 = self._make_layer(block, filters[3], self.layers[3], stride=2)
+        block = Resnets[resnet]['block']
+        self.encoder1 = self._make_layer(block, filters[0], layers[0])
+        self.encoder2 = self._make_layer(block, filters[1], layers[1], stride=2)
+        self.encoder3 = self._make_layer(block, filters[2], layers[2], stride=2)
+        self.encoder4 = self._make_layer(block, filters[3], layers[3], stride=2)
         self.avgpool = nn.AvgPool2d(7)
 
 
         # Decoder
-        self.decoder4 = linknetUp(filters[3], filters[2])
-        self.decoder3 = linknetUp(filters[2], filters[1])
-        self.decoder2 = linknetUp(filters[1], filters[0])
-        self.decoder1 = linknetUp(filters[0], filters[0])
+        self.decoder4 = linknetUp(filters[3]*expansion, filters[2]*expansion)
+        self.decoder3 = linknetUp(filters[2]*expansion, filters[1]*expansion)
+        self.decoder2 = linknetUp(filters[1]*expansion, filters[0]*expansion)
+        self.decoder1 = linknetUp(filters[0]*expansion, filters[0])
 
         # Final Classifier
         self.finaldeconvbnrelu1 = deconv2DBatchNormRelu(filters[0], 32/feature_scale, 2, 2, 0)
@@ -78,4 +88,3 @@ class pspnet(nn.Module):
         f3 = self.finalconv3(f2)
 
         return f3
-

--- a/ptsemseg/models/pspnet.py
+++ b/ptsemseg/models/pspnet.py
@@ -33,9 +33,9 @@ class pspnet(nn.Module):
 
         # Decoder
         self.decoder4 = linknetUp(filters[3], filters[2])
-        self.decoder4 = linknetUp(filters[2], filters[1])
-        self.decoder4 = linknetUp(filters[1], filters[0])
-        self.decoder4 = linknetUp(filters[0], filters[0])
+        self.decoder3 = linknetUp(filters[2], filters[1])
+        self.decoder2 = linknetUp(filters[1], filters[0])
+        self.decoder1 = linknetUp(filters[0], filters[0])
 
         # Final Classifier
         self.finaldeconvbnrelu1 = nn.Sequential(nn.ConvTranspose2d(filters[0], 32/feature_scale, 3, 2, 1),

--- a/ptsemseg/models/utils.py
+++ b/ptsemseg/models/utils.py
@@ -229,13 +229,13 @@ class linknetUp(nn.Module):
         super(linknetUp, self).__init__()
 
         # B, 2C, H, W -> B, C/2, H, W
-        self.convbnrelu1 = conv2DBatchNormRelu(in_channels, n_filters/2, k_size=1, stride=1, padding=1)
+        self.convbnrelu1 = conv2DBatchNormRelu(in_channels, n_filters/2, k_size=1, stride=1, padding=0)
 
-        # B, C/2, H, W -> B, C/2, H, W
-        self.deconvbnrelu2 = nn.deconv2DBatchNormRelu(n_filters/2, n_filters/2, k_size=3,  stride=2, padding=0,)
+        # B, C/2, H, W -> B, C/2, 2H, 2W
+        self.deconvbnrelu2 = deconv2DBatchNormRelu(n_filters/2, n_filters/2, k_size=2,  stride=2, padding=0)
 
-        # B, C/2, H, W -> B, C, H, W
-        self.convbnrelu3 = conv2DBatchNormRelu(n_filters/2, n_filters, k_size=1, stride=1, padding=1)
+        # B, C/2, 2H, 2W -> B, C, 2H, 2W
+        self.convbnrelu3 = conv2DBatchNormRelu(n_filters/2, n_filters, k_size=1, stride=1, padding=0)
 
     def forward(self, x):
         x = self.convbnrelu1(x)

--- a/ptsemseg/models/utils.py
+++ b/ptsemseg/models/utils.py
@@ -201,9 +201,9 @@ class residualBottleneck(nn.Module):
 
     def __init__(self, in_channels, n_filters, stride=1, downsample=None):
         super(residualBottleneck, self).__init__()
-        self.convbn1 = nn.Conv2DBatchNorm(in_channels,  n_filters, k_size=1, bias=False)
-        self.convbn2 = nn.Conv2DBatchNorm(n_filters,  n_filters, k_size=3, padding=1, stride=stride, bias=False)
-        self.convbn3 = nn.Conv2DBatchNorm(n_filters,  n_filters * 4, k_size=1, bias=False)
+        self.convbn1 = conv2DBatchNorm(in_channels,  n_filters, k_size=1, stride=1, padding=0, bias=False)
+        self.convbn2 = conv2DBatchNorm(n_filters,  n_filters, k_size=3,  stride=stride, padding=1, bias=False)
+        self.convbn3 = conv2DBatchNorm(n_filters,  n_filters * self.expansion, k_size=1, stride=1, padding=0, bias=False)
         self.relu = nn.ReLU(inplace=True)
         self.downsample = downsample
         self.stride = stride

--- a/train.py
+++ b/train.py
@@ -15,6 +15,24 @@ from ptsemseg.loader import get_loader, get_data_path
 from ptsemseg.loss import cross_entropy2d
 from ptsemseg.metrics import scores
 
+
+def poly_lr_scheduler(optimizer, init_lr, iter, lr_decay_iter=1, max_iter=30000, power=0.9,):
+    """Polynomial decay of learning rate
+        :param init_lr is base learning rate
+        :param iter is a current iteration
+        :param lr_decay_iter how frequently decay occurs, default is 1
+        :param max_iter is number of maximum iterations
+        :param power is a polymomial power
+
+    """
+    if iter % lr_decay_iter or iter > max_iter:
+        return optimizer
+
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = init_lr*(1 - iter/max_iter)**power
+    return optimizer
+
+
 def train(args):
 
     # Setup Dataloader

--- a/train.py
+++ b/train.py
@@ -14,24 +14,7 @@ from ptsemseg.models import get_model
 from ptsemseg.loader import get_loader, get_data_path
 from ptsemseg.loss import cross_entropy2d
 from ptsemseg.metrics import scores
-
-
-def poly_lr_scheduler(optimizer, init_lr, iter, lr_decay_iter=1, max_iter=30000, power=0.9,):
-    """Polynomial decay of learning rate
-        :param init_lr is base learning rate
-        :param iter is a current iteration
-        :param lr_decay_iter how frequently decay occurs, default is 1
-        :param max_iter is number of maximum iterations
-        :param power is a polymomial power
-
-    """
-    if iter % lr_decay_iter or iter > max_iter:
-        return optimizer
-
-    for param_group in optimizer.param_groups:
-        param_group['lr'] = init_lr*(1 - iter/max_iter)**power
-    return optimizer
-
+from lr_scheduling import *
 
 def train(args):
 
@@ -74,6 +57,9 @@ def train(args):
                 images = Variable(images)
                 labels = Variable(labels)
 
+            iter = len(trainloader)*epoch + i
+            poly_lr_scheduler(optimizer, args.l_rate, iter)
+            
             optimizer.zero_grad()
             outputs = model(images)
 


### PR DESCRIPTION
I have managed to make a clean PR with this one. I think in the last ones I merged the upstream instead of rebasing it . 
To keep things cleaner, I also created a branch called resnet-encoders. Which now contains the previous bug fix in resnet 18 and additionally multiple resnet support.
I think it is better to use pre-trained resnet but we should also keep the resnet architecture in case one wants to train it from scratch for some reason best known to him.
I will shortly add the pretrained model support as well.