### PR TITLE
Fix issue in convert_state_dict

### DIFF
--- a/ptsemseg/utils.py
+++ b/ptsemseg/utils.py
@@ -1,7 +1,7 @@
 '''
 Misc Utility functions
 '''
-
+from collections import OrderedDict
 import os
 import numpy as np
 
@@ -54,10 +54,8 @@ def convert_state_dict(state_dict):
        :param state_dict is the loaded DataParallel model_state
     
     """
-    
+    new_state_dict = OrderedDict()
     for k, v in state_dict.items():
         name = k[7:] # remove `module.`
-        state_dict[name] = v
-        del state_dict[k]
-    return state_dict
-
+        new_state_dict[name] = v
+    return new_state_dict


### PR DESCRIPTION
This is a fix for Issue #69. The `RuntimeError` is raised because the `OrderedDict` is mutated while being iterated over.