### PR TITLE
Update PSPNet and ICNet

### DIFF
--- a/ptsemseg/loader/camvid_loader.py
+++ b/ptsemseg/loader/camvid_loader.py
@@ -11,12 +11,13 @@ from ptsemseg.augmentations import *
 
 class camvidLoader(data.Dataset):
     def __init__(self, root, split="train", 
-                 is_transform=False, img_size=None, augmentations=None):
+                 is_transform=False, img_size=None, augmentations=None, img_norm=True):
         self.root = root
         self.split = split
         self.img_size = [360, 480]
         self.is_transform = is_transform
         self.augmentations = augmentations
+        self.img_norm = img_norm
         self.mean = np.array([104.00699, 116.66877, 122.67892])
         self.n_classes = 12
         self.files = collections.defaultdict(list)
@@ -48,10 +49,14 @@ class camvidLoader(data.Dataset):
         return img, lbl
 
     def transform(self, img, lbl):
-        img = img[:, :, ::-1]
+        img = m.imresize(img, (self.img_size[0], self.img_size[1])) # uint8 with RGB mode
+        img = img[:, :, ::-1] # RGB -> BGR
         img = img.astype(np.float64)
         img -= self.mean
-        img = img.astype(float) / 255.0
+        if self.img_norm:
+            # Resize scales images from 0 to 255, thus we need
+            # to divide by 255.0
+            img = img.astype(float) / 255.0
         # NHWC -> NCHW
         img = img.transpose(2, 0, 1)
 

--- a/ptsemseg/loader/nyuv2_loader.py
+++ b/ptsemseg/loader/nyuv2_loader.py
@@ -25,11 +25,12 @@ class NYUv2Loader(data.Dataset):
     """
     
     
-    def __init__(self, root, split="training", is_transform=False, img_size=(480,640), augmentations=None):
+    def __init__(self, root, split="training", is_transform=False, img_size=(480,640), augmentations=None, img_norm=True):
         self.root = root
         self.is_transform = is_transform
         self.n_classes = 14
         self.augmentations = augmentations
+        self.img_norm = img_norm
         self.img_size = img_size if isinstance(img_size, tuple) else (img_size, img_size)
         self.mean = np.array([104.00699, 116.66877, 122.67892])
         self.files = collections.defaultdict(list)
@@ -71,14 +72,15 @@ class NYUv2Loader(data.Dataset):
 
 
     def transform(self, img, lbl):
-        img = img[:, :, ::-1]
+        img = m.imresize(img, (self.img_size[0], self.img_size[1])) # uint8 with RGB mode
+        img = img[:, :, ::-1] # RGB -> BGR
         img = img.astype(np.float64)
         img -= self.mean
-        img = m.imresize(img, (self.img_size[0], self.img_size[1]))
-        # Resize scales images from 0 to 255, thus we need
-        # to divide by 255.0
-        img = img.astype(float) / 255.0
-        # NHWC -> NCWH
+        if self.img_norm:
+            # Resize scales images from 0 to 255, thus we need
+            # to divide by 255.0
+            img = img.astype(float) / 255.0
+        # NHWC -> NCHW
         img = img.transpose(2, 0, 1)
 
         classes = np.unique(lbl)

--- a/ptsemseg/loss.py
+++ b/ptsemseg/loss.py
@@ -1,28 +1,26 @@
 import torch
 import numpy as np
-import scipy.misc as m
 import torch.nn as nn
 import torch.nn.functional as F
-
-from torch.autograd import Variable
 
 
 def cross_entropy2d(input, target, weight=None, size_average=True):
     n, c, h, w = input.size()
     nt, ht, wt = target.size()
 
-    if h != ht or w != wt: # inconsistent size between input and target
-        lbl = target.data.cpu().numpy()
-        lbl = lbl.astype(float)
-        lbl_resized = np.zeros((n, h, w))
-        for i in range(nt):
-            lbl_resized[i,:,:] = m.imresize(lbl[i,:,:], (h, w), 'nearest', mode='F')
-        lbl_resized = lbl_resized.astype(int)
-        target = Variable(torch.from_numpy(lbl_resized).long().cuda())
+    # Handle inconsistent size between input and target
+    if h > ht and w > wt: # upsample labels
+        target = target.unsequeeze(1)
+        target = F.upsample(target, size=(h, w), mode='nearest')
+        target = target.sequeeze(1)
+    elif h < ht and w < wt: # upsample images
+        input = F.upsample(input, size=(ht, wt), mode='bilinear')
+    elif h != ht and w != wt:
+        raise Exception("Only support upsampling")
 
     log_p = F.log_softmax(input, dim=1)
     log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous().view(-1, c)
-    log_p = log_p[target.view(n * h * w, 1).repeat(1, c) >= 0]
+    log_p = log_p[target.view(-1, 1).repeat(1, c) >= 0]
     log_p = log_p.view(-1, c)
 
     mask = target >= 0
@@ -62,3 +60,17 @@ def bootstrapped_cross_entropy2d(input, target, K, weight=None, size_average=Tru
                                            weight=weight,
                                            size_average=size_average)
     return loss / float(batch_size)
+
+
+def multi_scale_cross_entropy2d(input, target, weight=None, size_average=True, scale_weight=None):
+    # Auxiliary training for PSPNet [1.0, 0.4] and ICNet [1.0, 0.4, 0.16]
+    if scale_weight == None: # scale_weight: torch tensor type
+        n_inp = len(input)
+        scale = 0.4
+        scale_weight = torch.pow(scale * torch.ones(n_inp), torch.arange(n_inp))
+
+    loss = 0.0
+    for i, inp in enumerate(input):
+        loss = loss + scale_weight[i] * cross_entropy2d(input=inp, target=target, weight=weight, size_average=size_average)
+
+    return loss

--- a/ptsemseg/loss.py
+++ b/ptsemseg/loss.py
@@ -9,14 +9,16 @@ from torch.autograd import Variable
 
 def cross_entropy2d(input, target, weight=None, size_average=True):
     n, c, h, w = input.size()
-    nt, ct, ht, wt = target.size()
+    nt, ht, wt = target.size()
 
     if h != ht or w != wt: # inconsistent size between input and target
         lbl = target.data.cpu().numpy()
         lbl = lbl.astype(float)
-        lbl = m.imresize(lbl, (h, w), 'nearest', mode='F')
-        lbl = lbl.astype(int)
-        target = Variable(torch.from_numpy(lbl).long().cuda())
+        lbl_resized = np.zeros((n, h, w))
+        for i in range(nt):
+            lbl_resized[i,:,:] = m.imresize(lbl[i,:,:], (h, w), 'nearest', mode='F')
+        lbl_resized = lbl_resized.astype(int)
+        target = Variable(torch.from_numpy(lbl_resized).long().cuda())
 
     log_p = F.log_softmax(input, dim=1)
     log_p = log_p.transpose(1, 2).transpose(2, 3).contiguous().view(-1, c)

--- a/ptsemseg/models/__init__.py
+++ b/ptsemseg/models/__init__.py
@@ -4,6 +4,7 @@ from ptsemseg.models.fcn import *
 from ptsemseg.models.segnet import *
 from ptsemseg.models.unet import *
 from ptsemseg.models.pspnet import *
+from ptsemseg.models.icnet import *
 from ptsemseg.models.linknet import *
 from ptsemseg.models.frrn import *
 
@@ -34,6 +35,11 @@ def get_model(name, n_classes, version=None):
     elif name == 'pspnet':
         model = model(n_classes=n_classes, version=version)
 
+    elif name == 'icnet':
+        model = model(n_classes=n_classes, with_bn=False, version=version)
+    elif name == 'icnetBN':
+        model = model(n_classes=n_classes, with_bn=True, version=version)
+
     else:
         model = model(n_classes=n_classes)
 
@@ -48,6 +54,8 @@ def _get_model_instance(name):
             'unet': unet,
             'segnet': segnet,
             'pspnet': pspnet,
+			'icnet': icnet,
+			'icnetBN': icnet,
             'linknet': linknet,
             'frrnA': frrn,
             'frrnB': frrn,

--- a/ptsemseg/models/__init__.py
+++ b/ptsemseg/models/__init__.py
@@ -8,7 +8,7 @@ from ptsemseg.models.linknet import *
 from ptsemseg.models.frrn import *
 
 
-def get_model(name, n_classes):
+def get_model(name, n_classes, version=None):
     model = _get_model_instance(name)
 
     if name in ['frrnA', 'frrnB']:
@@ -30,7 +30,10 @@ def get_model(name, n_classes):
                       is_batchnorm=True,
                       in_channels=3,
                       is_deconv=True)
-    
+
+    elif name == 'pspnet':
+        model = model(n_classes=n_classes, version=version)
+
     else:
         model = model(n_classes=n_classes)
 

--- a/ptsemseg/models/icnet.py
+++ b/ptsemseg/models/icnet.py
@@ -1,0 +1,415 @@
+import torch
+import numpy as np
+import torch.nn as nn
+
+from math import ceil
+from torch.autograd import Variable
+
+from ptsemseg import caffe_pb2
+from ptsemseg.models.utils import *
+from ptsemseg.loss import *
+
+icnet_specs = {
+    'cityscapes': 
+    {
+         'n_classes': 19,
+         'input_size': (1025, 2049),
+         'block_config': [3, 4, 6, 3],
+    },
+}
+
+class icnet(nn.Module):
+    
+    """
+    Image Cascade Network
+    URL: https://arxiv.org/abs/1704.08545
+
+    References:
+    1) Original Author's code: https://github.com/hszhao/ICNet
+    2) Chainer implementation by @mitmul: https://github.com/mitmul/chainer-pspnet
+    3) TensorFlow implementation by @hellochick: https://github.com/hellochick/ICNet-tensorflow
+
+    """
+
+    def __init__(self, 
+                 n_classes=19, 
+                 block_config=[3, 4, 6, 3], 
+                 input_size=(1025, 2049), 
+                 version=None,
+                 with_bn=True):
+
+        super(icnet, self).__init__()
+
+        bias = not with_bn
+        
+        self.block_config = icnet_specs[version]['block_config'] if version is not None else block_config
+        self.n_classes = icnet_specs[version]['n_classes'] if version is not None else n_classes
+        self.input_size = icnet_specs[version]['input_size'] if version is not None else input_size
+        
+        # Encoder
+        self.convbnrelu1_1 = conv2DBatchNormRelu(in_channels=3, k_size=3, n_filters=32,
+                                                 padding=1, stride=2, bias=bias, with_bn=with_bn)
+        self.convbnrelu1_2 = conv2DBatchNormRelu(in_channels=32, k_size=3, n_filters=32,
+                                                 padding=1, stride=1, bias=bias, with_bn=with_bn)
+        self.convbnrelu1_3 = conv2DBatchNormRelu(in_channels=32, k_size=3, n_filters=64,
+                                                 padding=1, stride=1, bias=bias, with_bn=with_bn)
+
+        # Vanilla Residual Blocks
+        self.res_block2 = residualBlockPSP(self.block_config[0], 64, 32, 128, 1, 1, with_bn=with_bn)
+        self.res_block3_conv = residualBlockPSP(self.block_config[1], 128, 64, 256, 2, 1, include_range='conv', with_bn=with_bn)
+        self.res_block3_identity = residualBlockPSP(self.block_config[1], 128, 64, 256, 2, 1, include_range='identity', with_bn=with_bn)
+        
+        # Dilated Residual Blocks
+        self.res_block4 = residualBlockPSP(self.block_config[2], 256, 128, 512, 1, 2, with_bn=with_bn)
+        self.res_block5 = residualBlockPSP(self.block_config[3], 512, 256, 1024, 1, 4, with_bn=with_bn)
+        
+        # Pyramid Pooling Module
+        self.pyramid_pooling = pyramidPooling(1024, [6, 3, 2, 1], model_name='icnet', fusion_mode='sum', with_bn=with_bn)
+       
+        # Final conv layer with kernel 1 in sub4 branch
+        self.conv5_4_k1 = conv2DBatchNormRelu(in_channels=1024, k_size=1, n_filters=256,
+                                              padding=0, stride=1, bias=bias, with_bn=with_bn)
+
+        # High-resolution (sub1) branch
+        self.convbnrelu1_sub1 = conv2DBatchNormRelu(in_channels=3, k_size=3, n_filters=32,
+                                                    padding=1, stride=2, bias=bias, with_bn=with_bn)
+        self.convbnrelu2_sub1 = conv2DBatchNormRelu(in_channels=32, k_size=3, n_filters=32,
+                                                    padding=1, stride=2, bias=bias, with_bn=with_bn)
+        self.convbnrelu3_sub1 = conv2DBatchNormRelu(in_channels=32, k_size=3, n_filters=64,
+                                                    padding=1, stride=2, bias=bias, with_bn=with_bn)
+        self.classification = nn.Conv2d(128, self.n_classes, 1, 1, 0)
+
+        # Cascade Feature Fusion Units
+        self.cff_sub24 = cascadeFeatureFusion(self.n_classes, 256, 256, 128, with_bn=with_bn)
+        self.cff_sub12 = cascadeFeatureFusion(self.n_classes, 128, 64, 128, with_bn=with_bn)
+
+        # Define auxiliary loss function
+        self.loss = multi_scale_cross_entropy2d
+
+    def forward(self, x):
+        h, w = x.shape[2:]
+
+        # H, W -> H/2, W/2
+        x_sub2 = interp(x, output_size=get_interp_size(x, s_factor=2))
+
+        # H/2, W/2 -> H/4, W/4
+        x_sub2 = self.convbnrelu1_1(x_sub2)
+        x_sub2 = self.convbnrelu1_2(x_sub2)
+        x_sub2 = self.convbnrelu1_3(x_sub2)
+
+        # H/4, W/4 -> H/8, W/8
+        x_sub2 = F.max_pool2d(x_sub2, 3, 2, 1)
+
+        # H/8, W/8 -> H/16, W/16
+        x_sub2 = self.res_block2(x_sub2)
+        x_sub2 = self.res_block3_conv(x_sub2)
+        # H/16, W/16 -> H/32, W/32
+        x_sub4 = interp(x_sub2, output_size=get_interp_size(x_sub2, s_factor=2))
+        x_sub4 = self.res_block3_identity(x_sub4)
+
+        x_sub4 = self.res_block4(x_sub4)
+        x_sub4 = self.res_block5(x_sub4)
+
+        x_sub4 = self.pyramid_pooling(x_sub4)
+        x_sub4 = self.conv5_4_k1(x_sub4)
+
+        x_sub1 = self.convbnrelu1_sub1(x)
+        x_sub1 = self.convbnrelu2_sub1(x_sub1)
+        x_sub1 = self.convbnrelu3_sub1(x_sub1)
+
+        x_sub24, sub4_cls = self.cff_sub24(x_sub4, x_sub2)
+        x_sub12, sub24_cls = self.cff_sub12(x_sub24, x_sub1)
+
+        x_sub12 = F.upsample(x_sub12, size=get_interp_size(x_sub12, z_factor=2), mode='bilinear')
+        sub124_cls = self.classification(x_sub12)
+
+        if self.training:
+            return sub4_cls, sub24_cls, sub124_cls
+        else: # eval mode
+            sub124_cls = F.upsample(sub124_cls, size=get_interp_size(sub124_cls, z_factor=4), mode='bilinear') # Test only
+            return sub124_cls
+
+    def load_pretrained_model(self, model_path):
+        """
+        Load weights from caffemodel w/o caffe dependency
+        and plug them in corresponding modules
+        """
+        # My eyes and my heart both hurt when writing this method
+
+        # Only care about layer_types that have trainable parameters
+        ltypes = ['BNData', 'ConvolutionData', 'HoleConvolutionData', 'Convolution'] # Convolution type for conv3_sub1_proj
+
+        def _get_layer_params(layer, ltype):
+
+            if ltype == 'BNData':
+                gamma = np.array(layer.blobs[0].data)
+                beta = np.array(layer.blobs[1].data)
+                mean = np.array(layer.blobs[2].data)
+                var =  np.array(layer.blobs[3].data)
+                return [mean, var, gamma, beta]
+
+            elif ltype in ['ConvolutionData', 'HoleConvolutionData', 'Convolution']:
+                is_bias = layer.convolution_param.bias_term
+                weights = np.array(layer.blobs[0].data)
+                bias = []
+                if is_bias:
+                    bias = np.array(layer.blobs[1].data)
+                return [weights, bias]
+            
+            elif ltype == 'InnerProduct':
+                raise Exception("Fully connected layers {}, not supported".format(ltype))
+
+            else:
+                raise Exception("Unkown layer type {}".format(ltype))
+
+
+        net = caffe_pb2.NetParameter()
+        with open(model_path, 'rb') as model_file:
+            net.MergeFromString(model_file.read())
+
+        # dict formatted as ->  key:<layer_name> :: value:<layer_type>
+        layer_types = {}
+        # dict formatted as ->  key:<layer_name> :: value:[<list_of_params>]
+        layer_params = {}
+
+        for l in net.layer:
+            lname = l.name
+            ltype = l.type
+            lbottom = l.bottom
+            ltop = l.top
+            if ltype in ltypes:
+                print("Processing layer {} | {}, {}".format(lname, lbottom, ltop))
+                layer_types[lname] = ltype
+                layer_params[lname] = _get_layer_params(l, ltype)
+            #if len(l.blobs) > 0:
+            #    print(lname, ltype, lbottom, ltop, len(l.blobs))
+
+        # Set affine=False for all batchnorm modules
+        def _no_affine_bn(module=None):
+            if isinstance(module, nn.BatchNorm2d):
+                module.affine = False
+
+            if len([m for m in module.children()]) > 0:
+                for child in module.children():
+                    _no_affine_bn(child)
+
+        #_no_affine_bn(self)
+
+
+        def _transfer_conv(layer_name, module):
+            weights, bias = layer_params[layer_name]
+            w_shape = np.array(module.weight.size())
+            
+            print("CONV {}: Original {} and trans weights {}".format(layer_name,
+                                                                  w_shape,
+                                                                  weights.shape))
+
+            module.weight.data.copy_(torch.from_numpy(weights).view_as(module.weight))
+
+            if len(bias) != 0:
+                b_shape = np.array(module.bias.size())
+                print("CONV {}: Original {} and trans bias {}".format(layer_name,
+                                                                      b_shape,
+                                                                      bias.shape))
+                module.bias.data.copy_(torch.from_numpy(bias).view_as(module.bias))
+
+
+        def _transfer_bn(conv_layer_name, bn_module):
+            mean, var, gamma, beta = layer_params[conv_layer_name+'/bn']
+            print("BN {}: Original {} and trans weights {}".format(conv_layer_name,
+                                                                   bn_module.running_mean.size(),
+                                                                   mean.shape))
+            bn_module.running_mean.copy_(torch.from_numpy(mean).view_as(bn_module.running_mean))
+            bn_module.running_var.copy_(torch.from_numpy(var).view_as(bn_module.running_var))
+            bn_module.weight.data.copy_(torch.from_numpy(gamma).view_as(bn_module.weight))
+            bn_module.bias.data.copy_(torch.from_numpy(beta).view_as(bn_module.bias))
+
+
+        def _transfer_conv_bn(conv_layer_name, mother_module):
+            conv_module = mother_module[0]
+            _transfer_conv(conv_layer_name, conv_module)
+
+            if conv_layer_name+'/bn' in layer_params.keys():
+                bn_module = mother_module[1]
+                _transfer_bn(conv_layer_name, bn_module)
+
+
+        def _transfer_residual(block_name, block):
+            block_module, n_layers = block[0], block[1]
+            prefix = block_name[:5]
+
+            if ('bottleneck' in block_name) or ('identity' not in block_name): # Conv block
+                bottleneck = block_module.layers[0]
+                bottleneck_conv_bn_dic = {prefix + '_1_1x1_reduce': bottleneck.cbr1.cbr_unit,
+                                          prefix + '_1_3x3': bottleneck.cbr2.cbr_unit,
+                                          prefix + '_1_1x1_proj': bottleneck.cb4.cb_unit,
+                                          prefix + '_1_1x1_increase': bottleneck.cb3.cb_unit,}
+
+                for k, v in bottleneck_conv_bn_dic.items():
+                    _transfer_conv_bn(k, v)
+
+            if ('identity' in block_name) or ('bottleneck' not in block_name): # Identity blocks
+                base_idx = 2 if 'identity' in block_name else 1
+
+                for layer_idx in range(2, n_layers+1):
+                    residual_layer = block_module.layers[layer_idx-base_idx]
+                    residual_conv_bn_dic = {'_'.join(map(str, [prefix, layer_idx, '1x1_reduce'])): residual_layer.cbr1.cbr_unit,
+                                            '_'.join(map(str, [prefix, layer_idx, '3x3'])):  residual_layer.cbr2.cbr_unit,
+                                            '_'.join(map(str, [prefix, layer_idx, '1x1_increase'])): residual_layer.cb3.cb_unit,} 
+                    
+                    for k, v in residual_conv_bn_dic.items():
+                        _transfer_conv_bn(k, v)
+
+
+        convbn_layer_mapping = {'conv1_1_3x3_s2': self.convbnrelu1_1.cbr_unit,
+                                'conv1_2_3x3': self.convbnrelu1_2.cbr_unit,
+                                'conv1_3_3x3': self.convbnrelu1_3.cbr_unit,
+                                'conv1_sub1': self.convbnrelu1_sub1.cbr_unit,
+                                'conv2_sub1': self.convbnrelu2_sub1.cbr_unit,
+                                'conv3_sub1': self.convbnrelu3_sub1.cbr_unit,
+                                #'conv5_3_pool6_conv': self.pyramid_pooling.paths[0].cbr_unit, 
+                                #'conv5_3_pool3_conv': self.pyramid_pooling.paths[1].cbr_unit,
+                                #'conv5_3_pool2_conv': self.pyramid_pooling.paths[2].cbr_unit,
+                                #'conv5_3_pool1_conv': self.pyramid_pooling.paths[3].cbr_unit,
+                                'conv5_4_k1': self.conv5_4_k1.cbr_unit,
+                                'conv_sub4': self.cff_sub24.low_dilated_conv_bn.cb_unit,
+                                'conv3_1_sub2_proj': self.cff_sub24.high_proj_conv_bn.cb_unit,
+                                'conv_sub2': self.cff_sub12.low_dilated_conv_bn.cb_unit,
+                                'conv3_sub1_proj': self.cff_sub12.high_proj_conv_bn.cb_unit,}
+
+        residual_layers = {'conv2': [self.res_block2, self.block_config[0]],
+                           'conv3_bottleneck': [self.res_block3_conv, self.block_config[1]],
+                           'conv3_identity': [self.res_block3_identity, self.block_config[1]],
+                           'conv4': [self.res_block4, self.block_config[2]],
+                           'conv5': [self.res_block5, self.block_config[3]],}
+
+        # Transfer weights for all non-residual conv+bn layers
+        for k, v in convbn_layer_mapping.items():
+            _transfer_conv_bn(k, v)
+
+        # Transfer weights for final non-bn conv layer
+        _transfer_conv('conv6_cls', self.classification)
+        _transfer_conv('conv6_sub4', self.cff_sub24.low_classifier_conv)
+        _transfer_conv('conv6_sub2', self.cff_sub12.low_classifier_conv)
+
+        # Transfer weights for all residual layers
+        for k, v in residual_layers.items():
+            _transfer_residual(k, v)
+
+
+    def tile_predict(self, imgs, include_flip_mode=True):
+        """
+        Predict by takin overlapping tiles from the image.
+
+        Strides are adaptively computed from the imgs shape
+        and input size
+
+        :param imgs: torch.Tensor with shape [N, C, H, W] in BGR format
+        :param side: int with side length of model input
+        :param n_classes: int with number of classes in seg output.
+        """
+
+        side_x, side_y = self.input_size
+        n_classes = self.n_classes
+        n_samples, c, h, w = imgs.shape
+        #n = int(max(h,w) / float(side) + 1)
+        n_x = int(h / float(side_x) + 1)
+        n_y = int(w / float(side_y) + 1)
+        stride_x = ( h - side_x ) / float(n_x)
+        stride_y = ( w - side_y ) / float(n_y)
+
+        x_ends = [[int(i*stride_x), int(i*stride_x) + side_x] for i in range(n_x+1)]
+        y_ends = [[int(i*stride_y), int(i*stride_y) + side_y] for i in range(n_y+1)]
+
+        pred = np.zeros([n_samples, n_classes, h, w])
+        count = np.zeros([h, w])
+
+        slice_count = 0
+        for sx, ex in x_ends:
+            for sy, ey in y_ends:
+                slice_count += 1
+            
+                imgs_slice = imgs[:, :, sx:ex, sy:ey]
+                if include_flip_mode:
+                    imgs_slice_flip = torch.from_numpy(np.copy(imgs_slice.cpu().numpy()[:, :, :, ::-1])).float()
+
+                is_model_on_cuda = next(self.parameters()).is_cuda
+
+                inp = Variable(imgs_slice, volatile=True)
+                if include_flip_mode:
+                    flp = Variable(imgs_slice_flip, volatile=True)
+                
+                if is_model_on_cuda:
+                    inp = inp.cuda()
+                    if include_flip_mode:
+                        flp = flp.cuda()
+
+                psub1 = F.softmax(self.forward(inp), dim=1).data.cpu().numpy()
+                if include_flip_mode:
+                    psub2 = F.softmax(self.forward(flp), dim=1).data.cpu().numpy()
+                    psub = (psub1 + psub2[:, :, :, ::-1]) / 2.0
+                else:
+                    psub = psub1
+    
+                pred[:, :, sx:ex, sy:ey] = psub
+                count[sx:ex, sy:ey] += 1.0
+ 
+        score = (pred / count[None, None, ...]).astype(np.float32)
+        return score / np.expand_dims(score.sum(axis=1), axis=1)
+
+
+
+# For Testing Purposes only
+if __name__ == '__main__':
+    cd = 0
+    import os
+    from torch.autograd import Variable
+    import matplotlib.pyplot as plt
+    import scipy.misc as m
+    from ptsemseg.loader.cityscapes_loader import cityscapesLoader as cl
+    ic = icnet(version='cityscapes', with_bn=False)
+
+    # Just need to do this one time
+    caffemodel_dir_path = 'PATH_TO_ICNET_DIR/evaluation/model'
+    ic.load_pretrained_model(model_path=os.path.join(caffemodel_dir_path, 'icnet_cityscapes_train_30k.caffemodel'))
+    #ic.load_pretrained_model(model_path=os.path.join(caffemodel_dir_path, 'icnet_cityscapes_train_30k_bnnomerge.caffemodel'))
+    #ic.load_pretrained_model(model_path=os.path.join(caffemodel_dir_path, 'icnet_cityscapes_trainval_90k.caffemodel'))
+    #ic.load_pretrained_model(model_path=os.path.join(caffemodel_dir_path, 'icnet_cityscapes_trainval_90k_bnnomerge.caffemodel'))
+    
+    # ic.load_state_dict(torch.load('ic.pth'))
+
+    ic.float()
+    ic.cuda(cd)
+    ic.eval()
+
+    dataset_root_dir = 'PATH_TO_CITYSCAPES_DIR'
+    dst = cl(root=dataset_root_dir)
+    img = m.imread(os.path.join(dataset_root_dir, 'leftImg8bit/demoVideo/stuttgart_00/stuttgart_00_000000_000010_leftImg8bit.png'))
+    m.imsave('test_input.png', img)
+    orig_size = img.shape[:-1]
+    img = m.imresize(img, ic.input_size) # uint8 with RGB mode
+    img = img.transpose(2, 0, 1)
+    img = img.astype(np.float64)
+    img -= np.array([123.68, 116.779, 103.939])[:, None, None]
+    img = np.copy(img[::-1, :, :])
+    img = torch.from_numpy(img).float()
+    img = img.unsqueeze(0)
+
+    out = ic.tile_predict(img)
+    pred = np.argmax(out, axis=1)[0]
+    pred = pred.astype(np.float32)
+    pred = m.imresize(pred, orig_size, 'nearest', mode='F') # float32 with F mode
+    decoded = dst.decode_segmap(pred)
+    m.imsave('test_output.png', decoded)
+    #m.imsave('test_output.png', pred) 
+
+    checkpoints_dir_path = 'checkpoints'
+    if not os.path.exists(checkpoints_dir_path):
+        os.mkdir(checkpoints_dir_path)
+    ic = torch.nn.DataParallel(ic, device_ids=range(torch.cuda.device_count()))
+    state = {'model_state': ic.state_dict()}
+    torch.save(state, os.path.join(checkpoints_dir_path, "icnet_cityscapes_train_30k.pth"))
+    #torch.save(state, os.path.join(checkpoints_dir_path, "icnetBN_cityscapes_train_30k.pth"))
+    #torch.save(state, os.path.join(checkpoints_dir_path, "icnet_cityscapes_trainval_90k.pth"))
+    #torch.save(state, os.path.join(checkpoints_dir_path, "icnetBN_cityscapes_trainval_90k.pth"))
+    print("Output Shape {} \t Input Shape {}".format(out.shape, img.shape))

--- a/ptsemseg/models/utils.py
+++ b/ptsemseg/models/utils.py
@@ -375,17 +375,17 @@ class bottleNeckPSP(nn.Module):
                  stride, dilation=1):
         super(bottleNeckPSP, self).__init__()
             
-        self.cbr1 = conv2DBatchNormRelu(in_channels, mid_channels, 1, 1, 0, bias=False) 
+        self.cbr1 = conv2DBatchNormRelu(in_channels, mid_channels, 1, stride=1, padding=0, bias=False) 
         if dilation > 1: 
-            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3, 1, 
-                                            padding=dilation, bias=False, 
-                                            dilation=dilation) 
+            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3,
+                                            stride=stride, padding=dilation,
+                                            bias=False, dilation=dilation) 
         else:
-            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3, 
-                                            stride=stride, padding=1, 
+            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3,
+                                            stride=stride, padding=1,
                                             bias=False, dilation=1)
-        self.cb3 = conv2DBatchNorm(mid_channels, out_channels, 1, 1, 0, bias=False)
-        self.cb4 = conv2DBatchNorm(in_channels, out_channels, 1, stride, 0, bias=False)
+        self.cb3 = conv2DBatchNorm(mid_channels, out_channels, 1, stride=1, padding=0, bias=False)
+        self.cb4 = conv2DBatchNorm(in_channels, out_channels, 1, stride=stride, padding=0, bias=False)
 
     def forward(self, x):
         conv = self.cb3(self.cbr2(self.cbr1(x)))
@@ -400,14 +400,14 @@ class bottleNeckIdentifyPSP(nn.Module):
 
         self.cbr1 = conv2DBatchNormRelu(in_channels, mid_channels, 1, 1, 0, bias=False) 
         if dilation > 1: 
-            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3, 1, 
-                                            padding=dilation, bias=False, 
-                                            dilation=dilation) 
+            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3,
+                                            stride=1, padding=dilation,
+                                            bias=False, dilation=dilation) 
         else:
-            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3, 
+            self.cbr2 = conv2DBatchNormRelu(mid_channels, mid_channels, 3,
                                             stride=1, padding=1, 
                                             bias=False, dilation=1)
-        self.cb3 = conv2DBatchNorm(mid_channels, in_channels, 1, 1, 0, bias=False)
+        self.cb3 = conv2DBatchNorm(mid_channels, in_channels, 1, stride=1, padding=0, bias=False)
         
     def forward(self, x):
         residual = x
@@ -424,7 +424,7 @@ class residualBlockPSP(nn.Module):
             stride = 1
 
         layers = [bottleNeckPSP(in_channels, mid_channels, out_channels, stride, dilation)]
-        for i in range(n_blocks):
+        for i in range(n_blocks-1):
             layers.append(bottleNeckIdentifyPSP(out_channels, mid_channels, stride, dilation))
 
         self.layers = nn.Sequential(*layers)

--- a/test.py
+++ b/test.py
@@ -1,10 +1,10 @@
-import sys
+import sys, os
 import torch
 import visdom
 import argparse
 import numpy as np
-import torch.nn as nn
 import scipy.misc as misc
+import torch.nn as nn
 import torch.nn.functional as F
 import torchvision.models as models
 
@@ -30,18 +30,19 @@ def test(args):
     
     data_loader = get_loader(args.dataset)
     data_path = get_data_path(args.dataset)
-    loader = data_loader(data_path, is_transform=True)
+    loader = data_loader(data_path, is_transform=True, img_norm=args.img_norm)
     n_classes = loader.n_classes
     
     resized_img = misc.imresize(img, (loader.img_size[0], loader.img_size[1]), interp='bicubic')
 
+    img = misc.imresize(img, (loader.img_size[0], loader.img_size[1]))
     img = img[:, :, ::-1]
     img = img.astype(np.float64)
     img -= loader.mean
-    img = misc.imresize(img, (loader.img_size[0], loader.img_size[1]))
-    img = img.astype(float) / 255.0
-    # NHWC -> NCWH
-    img = img.transpose(2, 0, 1) 
+    if args.img_norm:
+        img = img.astype(float) / 255.0
+    # NHWC -> NCHW
+    img = img.transpose(2, 0, 1)
     img = np.expand_dims(img, 0)
     img = torch.from_numpy(img).float()
 
@@ -56,7 +57,7 @@ def test(args):
 
     outputs = F.softmax(model(images), dim=1)
     
-    if args.dcrf == "True":
+    if args.dcrf:
         unary = outputs.data.cpu().numpy()
         unary = np.squeeze(unary, 0)
         unary = -np.log(unary)
@@ -96,8 +97,19 @@ if __name__ == '__main__':
                         help='Path to the saved model')
     parser.add_argument('--dataset', nargs='?', type=str, default='pascal', 
                         help='Dataset to use [\'pascal, camvid, ade20k etc\']')
-    parser.add_argument('--dcrf', nargs='?', type=str, default="False",
-                        help='Enable DenseCRF based post-processing')
+
+    parser.add_argument('--img_norm', dest='img_norm', action='store_true', 
+                        help='Enable input image scales normalization [0, 1] | True by default')
+    parser.add_argument('--no-img_norm', dest='img_norm', action='store_false', 
+                        help='Disable input image scales normalization [0, 1] | True by default')
+    parser.set_defaults(img_norm=True)
+
+    parser.add_argument('--dcrf', dest='dcrf', action='store_true', 
+                        help='Enable DenseCRF based post-processing | False by default')
+    parser.add_argument('--no-dcrf', dest='dcrf', action='store_false', 
+                        help='Disable DenseCRF based post-processing | False by default')
+    parser.set_defaults(dcrf=False)
+
     parser.add_argument('--img_path', nargs='?', type=str, default=None, 
                         help='Path of the input image')
     parser.add_argument('--out_path', nargs='?', type=str, default=None, 

--- a/train.py
+++ b/train.py
@@ -1,4 +1,4 @@
-import sys
+import sys, os
 import torch
 import visdom
 import argparse
@@ -26,8 +26,8 @@ def train(args):
     # Setup Dataloader
     data_loader = get_loader(args.dataset)
     data_path = get_data_path(args.dataset)
-    t_loader = data_loader(data_path, is_transform=True, img_size=(args.img_rows, args.img_cols), augmentations=data_aug)
-    v_loader = data_loader(data_path, is_transform=True, split='val', img_size=(args.img_rows, args.img_cols))
+    t_loader = data_loader(data_path, is_transform=True, img_size=(args.img_rows, args.img_cols), augmentations=data_aug, img_norm=args.img_norm)
+    v_loader = data_loader(data_path, is_transform=True, split='val', img_size=(args.img_rows, args.img_cols), img_norm=args.img_norm)
 
     n_classes = t_loader.n_classes
     trainloader = data.DataLoader(t_loader, batch_size=args.batch_size, num_workers=8, shuffle=True)
@@ -132,7 +132,14 @@ if __name__ == '__main__':
     parser.add_argument('--img_rows', nargs='?', type=int, default=256, 
                         help='Height of the input image')
     parser.add_argument('--img_cols', nargs='?', type=int, default=256, 
-                        help='Height of the input image')
+                        help='Width of the input image')
+
+    parser.add_argument('--img_norm', dest='img_norm', action='store_true', 
+                        help='Enable input image scales normalization [0, 1] | True by default')
+    parser.add_argument('--no-img_norm', dest='img_norm', action='store_false', 
+                        help='Disable input image scales normalization [0, 1] | True by default')
+    parser.set_defaults(img_norm=True)
+
     parser.add_argument('--n_epoch', nargs='?', type=int, default=100, 
                         help='# of the epochs')
     parser.add_argument('--batch_size', nargs='?', type=int, default=1, 
@@ -143,7 +150,12 @@ if __name__ == '__main__':
                         help='Divider for # of features to use')
     parser.add_argument('--resume', nargs='?', type=str, default=None,    
                         help='Path to previous saved model to restart from')
-    parser.add_argument('--visdom', nargs='?', type=bool, default=False, 
-                        help='Show visualization(s) on visdom | False by  default')
+
+    parser.add_argument('--visdom', dest='visdom', action='store_true', 
+                        help='Enable visualization(s) on visdom | False by default')
+    parser.add_argument('--no-visdom', dest='visdom', action='store_false', 
+                        help='Disable visualization(s) on visdom | False by default')
+    parser.set_defaults(visdom=False)
+
     args = parser.parse_args()
     train(args)

--- a/train.py
+++ b/train.py
@@ -86,16 +86,7 @@ def train(args):
             optimizer.zero_grad()
             outputs = model(images)
 
-            if args.arch == 'pspnet':
-                aux_cls, final_cls = outputs
-
-                aux_loss = loss_fn(input=aux_cls, target=labels)
-                final_loss = loss_fn(input=final_cls, target=labels)
-
-                LAMBDA1, LAMBDA2 = 0.4, 1.0
-                loss = LAMBDA1 * aux_loss + LAMBDA2 * final_loss
-            else:
-                loss = loss_fn(input=outputs, target=labels)
+            loss = loss_fn(input=outputs, target=labels)
 
             loss.backward()
             optimizer.step()

--- a/train.py
+++ b/train.py
@@ -86,7 +86,16 @@ def train(args):
             optimizer.zero_grad()
             outputs = model(images)
 
-            loss = loss_fn(input=outputs, target=labels)
+            if args.arch == 'pspnet':
+                aux_cls, final_cls = outputs
+
+                aux_loss = loss_fn(input=aux_cls, target=labels)
+                final_loss = loss_fn(input=final_cls, target=labels)
+
+                LAMBDA1, LAMBDA2 = 0.4, 1.0
+                loss = LAMBDA1 * aux_loss + LAMBDA2 * final_loss
+            else:
+                loss = loss_fn(input=outputs, target=labels)
 
             loss.backward()
             optimizer.step()

--- a/validate.py
+++ b/validate.py
@@ -1,8 +1,10 @@
-import sys
+import sys, os
 import torch
 import visdom
 import argparse
+import timeit
 import numpy as np
+import scipy.misc as misc
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision.models as models
@@ -23,30 +25,38 @@ torch.backends.cudnn.benchmark = True
 cudnn.benchmark = True
 
 def validate(args):
+    model_file_name = os.path.split(args.model_path)[1]
+    model_name = model_file_name[:model_file_name.find('_')]
 
     # Setup Dataloader
     data_loader = get_loader(args.dataset)
     data_path = get_data_path(args.dataset)
-    loader = data_loader(data_path, split=args.split, is_transform=True, img_size=(args.img_rows, args.img_cols))
+    loader = data_loader(data_path, split=args.split, is_transform=True, img_size=(args.img_rows, args.img_cols), img_norm=args.img_norm)
     n_classes = loader.n_classes
     valloader = data.DataLoader(loader, batch_size=args.batch_size, num_workers=4)
     running_metrics = runningScore(n_classes)
 
     # Setup Model
-    model = get_model(args.model_path[:args.model_path.find('_')], n_classes)
+    model = get_model(model_name, n_classes, version=args.dataset)
     state = convert_state_dict(torch.load(args.model_path)['model_state'])
     model.load_state_dict(state)
     model.eval()
+    model.cuda()
 
-    for i, (images, labels) in tqdm(enumerate(valloader)):
-        model.cuda()
+    for i, (images, labels) in enumerate(valloader):
+        start_time = timeit.default_timer()
+
         images = Variable(images.cuda(), volatile=True)
-        labels = Variable(labels.cuda(), volatile=True)
+        #labels = Variable(labels.cuda(), volatile=True)
 
         outputs = model(images)
         pred = outputs.data.max(1)[1].cpu().numpy()
-        gt = labels.data.cpu().numpy()
-        
+        #gt = labels.data.cpu().numpy()
+        gt = labels.numpy()
+
+        if args.measure_time:
+            elapsed_time = timeit.default_timer() - start_time
+            print('Inference time (iter {0:5d}): {1:3.5f} fps'.format(i+1, pred.shape[0]/elapsed_time))
         running_metrics.update(gt, pred)
 
     score, class_iou = running_metrics.get_scores()
@@ -66,10 +76,30 @@ if __name__ == '__main__':
     parser.add_argument('--img_rows', nargs='?', type=int, default=256, 
                         help='Height of the input image')
     parser.add_argument('--img_cols', nargs='?', type=int, default=256, 
-                        help='Height of the input image')
+                        help='Width of the input image')
+
+    parser.add_argument('--img_norm', dest='img_norm', action='store_true', 
+                        help='Enable input image scales normalization [0, 1] | True by default')
+    parser.add_argument('--no-img_norm', dest='img_norm', action='store_false', 
+                        help='Disable input image scales normalization [0, 1] | True by default')
+    parser.set_defaults(img_norm=True)
+
+    parser.add_argument('--include_flip_mode', dest='include_flip_mode', action='store_true', 
+                        help='Enable evaluation with flipped image | True by default')
+    parser.add_argument('--no-include_flip_mode', dest='include_flip_mode', action='store_false', 
+                        help='Disable evaluation with flipped image | True by default')
+    parser.set_defaults(include_flip_mode=True)
+
     parser.add_argument('--batch_size', nargs='?', type=int, default=1, 
                         help='Batch Size')
     parser.add_argument('--split', nargs='?', type=str, default='val', 
                         help='Split of dataset to test on')
+
+    parser.add_argument('--measure_time', dest='measure_time', action='store_true', 
+                        help='Enable evaluation with time (fps) measurement | True by default')
+    parser.add_argument('--no-measure_time', dest='measure_time', action='store_false', 
+                        help='Disable evaluation with time (fps) measurement | True by default')
+    parser.set_defaults(measure_time=True)
+
     args = parser.parse_args()
     validate(args)


### PR DESCRIPTION
Modifications:
1. In cityscapes_loader.py, add args for mean version and img_norm, and input type for scipy.misc.imresize needs to be uint8 with RGB mode (since original pretrained model uses pascal mean image, and image doesn't normalize to [0,1])
2. Fix wrong number n_blocks for bottoleNeckIdentityPSP in residualBlockPSP function (n_blocks -> n_blocks-1)
3. Add auxiliary training layers for training PSPNet
4. Modify tile_predict with flip arg and support for batch with tensor type
5. Add PSPNet support for training and testing (extra args: img_norm, eval_flip, measure_time)

Validation results on cityscapes validation set (mIoU/pAcc):
Without flip: 78.65/96.31
With flip: 78.80/96.34
I feed images into network input size: 1025x2049 and single scale (since model input is odd numbers (713x713))
Run on single GTX 1080TI, time is about 1.2~1.3 fps
`python validate.py --model_path checkpoints/pspnet_101_cityscapes.pth --dataset cityscapes
                   --img_rows 1025 --img_cols 2049 --no-img_norm --eval_flip --measure_time
                   --batch_size 2 --split val`

Pretrained models in pytorch:
[pspnet_50_ade20k.pth](https://drive.google.com/open?id=128SKSAhHda8NE5VDWXgIiUhLPP2sBJpf)
[pspnet_101_cityscapes.pth](https://drive.google.com/open?id=1cz_S-QTqWqV-9K8V_3Gwo6NZ60pI0Oz7)
[pspnet_101_pascalvoc.pth](https://drive.google.com/open?id=1btEmZlS19RP4w45tUICJha-juE4BGlz1)