### PR TITLE
Include protobuf in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torchvision==0.2.0
 tqdm==4.11.2
 visdom==0.1.1
 pydensecrf
+protobuf


### PR DESCRIPTION
I was trying to use the pspnet model and got an error from caffepb2.py, because it has these imports:
```
from google.protobuf.internal import enum_type_wrapper
from google.protobuf import descriptor as _descriptor
from google.protobuf import message as _message
from google.protobuf import reflection as _reflection
from google.protobuf import symbol_database as _symbol_database
from google.protobuf import descriptor_pb2
```

Installing the `protobuf` package fixes the issue.