### PR TITLE
mit_sceneparsing_benchmark: fix train error, support "same" config that does not resize image

### DIFF
--- a/ptsemseg/loader/mit_sceneparsing_benchmark_loader.py
+++ b/ptsemseg/loader/mit_sceneparsing_benchmark_loader.py
@@ -78,7 +78,7 @@ class MITSceneParsingBenchmarkLoader(data.Dataset):
             self.annotations_base, os.path.basename(img_path)[:-4] + ".png"
         )
 
-        img = m.imread(img_path)
+        img = m.imread(img_path, mode='RGB')
         img = np.array(img, dtype=np.uint8)
 
         lbl = m.imread(lbl_path)
@@ -98,9 +98,12 @@ class MITSceneParsingBenchmarkLoader(data.Dataset):
         :param img:
         :param lbl:
         """
-        img = m.imresize(
-            img, (self.img_size[0], self.img_size[1])
-        )  # uint8 with RGB mode
+        if self.img_size == ('same', 'same'):
+            pass
+        else:
+            img = m.imresize(
+                img, (self.img_size[0], self.img_size[1])
+            )  # uint8 with RGB mode
         img = img[:, :, ::-1]  # RGB -> BGR
         img = img.astype(np.float64)
         img -= self.mean
@@ -113,7 +116,10 @@ class MITSceneParsingBenchmarkLoader(data.Dataset):
 
         classes = np.unique(lbl)
         lbl = lbl.astype(float)
-        lbl = m.imresize(lbl, (self.img_size[0], self.img_size[1]), "nearest", mode="F")
+        if self.img_size == ('same', 'same'):
+            pass
+        else:
+            lbl = m.imresize(lbl, (self.img_size[0], self.img_size[1]), "nearest", mode="F")
         lbl = lbl.astype(int)
 
         if not np.all(classes == np.unique(lbl)):


### PR DESCRIPTION
With this fix I could train with `mit_sceneparsing_benchmark` dataset.

config:
```yml
model:
    arch: fcn8s
data:
    dataset: mit_sceneparsing_benchmark
    train_split: training
    val_split: validation
    img_rows: 512
    img_cols: 512
    path: /home/helin/dataset/ADEChallengeData2016/
training:
    train_iters: 300000
    batch_size: 1
    val_interval: 1000
    n_workers: 16
    print_interval: 50
    optimizer:
        name: 'sgd'
        lr: 1.0e-10
        weight_decay: 0.0005
        momentum: 0.99
    loss:
        name: 'cross_entropy'
        size_average: False
    lr_schedule:
    resume:
```