### PR TITLE
Update ICNet and loss

### DIFF
--- a/ptsemseg/loss.py
+++ b/ptsemseg/loss.py
@@ -68,6 +68,9 @@ def bootstrapped_cross_entropy2d(input, target, K, weight=None, size_average=Tru
 def multi_scale_cross_entropy2d(
     input, target, weight=None, size_average=True, scale_weight=None
 ):
+    if not isinstance(input, tuple): # when evaluation
+        return cross_entropy2d(input=input, target=target, weight=weight, size_average=size_average)
+
     # Auxiliary training for PSPNet [1.0, 0.4] and ICNet [1.0, 0.4, 0.16]
     if scale_weight == None:  # scale_weight: torch tensor type
         n_inp = len(input)

--- a/ptsemseg/loss.py
+++ b/ptsemseg/loss.py
@@ -11,10 +11,10 @@ def cross_entropy2d(input, target, weight=None, size_average=True):
     # Handle inconsistent size between input and target
     if h > ht and w > wt:  # upsample labels
         target = target.unsqueeze(1)
-        target = F.upsample(target, size=(h, w), mode="nearest")
+        target = F.interpolate(target.float(), size=(h, w), mode="nearest").long()
         target = target.squeeze(1)
     elif h < ht and w < wt:  # upsample images
-        input = F.upsample(input, size=(ht, wt), mode="bilinear")
+        input = F.interpolate(input, size=(ht, wt), mode="bilinear", align_corners=True)
     elif h != ht and w != wt:
         raise Exception("Only support upsampling")
 
@@ -72,9 +72,7 @@ def multi_scale_cross_entropy2d(
     if scale_weight == None:  # scale_weight: torch tensor type
         n_inp = len(input)
         scale = 0.4
-        scale_weight = torch.pow(scale * torch.ones(n_inp), torch.arange(n_inp))
-        if input.is_cuda:
-            scale_weight = scale_weight.cuda()
+        scale_weight = torch.pow(scale * torch.ones(n_inp), torch.arange(n_inp).float()).to('cuda' if input.is_cuda else 'cpu')
 
     loss = 0.0
     for i, inp in enumerate(input):

--- a/ptsemseg/loss/loss.py
+++ b/ptsemseg/loss/loss.py
@@ -11,10 +11,10 @@ def cross_entropy2d(input, target, weight=None, size_average=True):
     # Handle inconsistent size between input and target
     if h > ht and w > wt:  # upsample labels
         target = target.unsequeeze(1)
-        target = F.upsample(target, size=(h, w), mode="nearest")
+        target = F.interpolate(target.float(), size=(h, w), mode="nearest").long()
         target = target.sequeeze(1)
     elif h < ht and w < wt:  # upsample images
-        input = F.upsample(input, size=(ht, wt), mode="bilinear")
+        input = F.interpolate(input, size=(ht, wt), mode="bilinear", align_corners=True)
     elif h != ht and w != wt:
         raise Exception("Only support upsampling")
 
@@ -33,7 +33,7 @@ def multi_scale_cross_entropy2d(
     if scale_weight == None:  # scale_weight: torch tensor type
         n_inp = len(input)
         scale = 0.4
-        scale_weight = torch.pow(scale * torch.ones(n_inp), torch.arange(n_inp))
+        scale_weight = torch.pow(scale * torch.ones(n_inp), torch.arange(n_inp).float()).to('cuda' if input.is_cuda else 'cpu')
 
     loss = 0.0
     for i, inp in enumerate(input):

--- a/ptsemseg/loss/loss.py
+++ b/ptsemseg/loss/loss.py
@@ -10,9 +10,9 @@ def cross_entropy2d(input, target, weight=None, size_average=True):
 
     # Handle inconsistent size between input and target
     if h > ht and w > wt:  # upsample labels
-        target = target.unsequeeze(1)
+        target = target.unsqueeze(1)
         target = F.interpolate(target.float(), size=(h, w), mode="nearest").long()
-        target = target.sequeeze(1)
+        target = target.squeeze(1)
     elif h < ht and w < wt:  # upsample images
         input = F.interpolate(input, size=(ht, wt), mode="bilinear", align_corners=True)
     elif h != ht and w != wt:
@@ -29,6 +29,9 @@ def cross_entropy2d(input, target, weight=None, size_average=True):
 def multi_scale_cross_entropy2d(
     input, target, weight=None, size_average=True, scale_weight=None
 ):
+    if not isinstance(input, tuple): # when evaluation
+        return cross_entropy2d(input=input, target=target, weight=weight, size_average=size_average)
+
     # Auxiliary training for PSPNet [1.0, 0.4] and ICNet [1.0, 0.4, 0.16]
     if scale_weight == None:  # scale_weight: torch tensor type
         n_inp = len(input)

--- a/validate.py
+++ b/validate.py
@@ -36,7 +36,7 @@ def validate(cfg, args):
         split=cfg['data']['val_split'],
         is_transform=True,
         img_size=(cfg['data']['img_rows'], 
-                  cfg['data']['img_rows']),
+                  cfg['data']['img_cols']),
     )
 
     n_classes = loader.n_classes


### PR DESCRIPTION
* Specify tensor data type and device setting.
* Upgrade ICNet to pytorch 0.4.1: replace `interp` and `F.upsample` with `F.interpolate`.
* Use `cross_entropy2d` when evaluation in `multi_scale_cross_entropy2d` function.