### PR TITLE
Changed the 'same' to a fixed image sizes

### DIFF
--- a/configs/fcn8s_pascal.yml
+++ b/configs/fcn8s_pascal.yml
@@ -4,8 +4,8 @@ data:
     dataset: pascal
     train_split: train_aug
     val_split: val
-    img_rows: 'same'
-    img_cols: 'same'
+    img_rows: 128
+    img_cols: 128
     path: /private/home/meetshah/datasets/VOC/060817/VOCdevkit/VOC2012/
     sbd_path: /private/home/meetshah/datasets/VOC/benchmark_RELEASE/
 training:


### PR DESCRIPTION
When running the train.py with 'same' we get an error `RuntimeError: invalid argument 0: Sizes of tensors must match except in dimension 0. Got 306 and 375 in dimension 2 `