### PR TITLE
Make sure state_dict needs to be converted

### DIFF
--- a/ptsemseg/utils.py
+++ b/ptsemseg/utils.py
@@ -38,6 +38,8 @@ def convert_state_dict(state_dict):
        module state_dict inplace
        :param state_dict is the loaded DataParallel model_state
     """
+    if not next(iter(state_dict)).startswith("module."):
+        return state_dict  # abort if dict is not a DataParallel model_state
     new_state_dict = OrderedDict()
     for k, v in state_dict.items():
         name = k[7:]  # remove `module.`


### PR DESCRIPTION
Converting a state_dict by applying the "low-level" operation: `k[7:]` on all keys `k` leads to errors if the model state was not saved from a DataParallel-enabled model. This happens, e.g., if a user trains both on machines with one and more than one GPU. Adding this "emergency exit" might not strictly be necessary if users took care of this in their scripts themselves. On the other hand, this is a minor and cheap check, which will save users (like me) from some very confusing errors (truncated and thus not matching keys).