### PR TITLE
Update loss.py

### DIFF
--- a/ptsemseg/loss/loss.py
+++ b/ptsemseg/loss/loss.py
@@ -27,7 +27,7 @@ def multi_scale_cross_entropy2d(input, target, weight=None, size_average=True, s
         n_inp = len(input)
         scale = 0.4
         scale_weight = torch.pow(scale * torch.ones(n_inp), torch.arange(n_inp).float()).to(
-            input.device
+            target.device
         )
 
     loss = 0.0


### PR DESCRIPTION
fix incorrect implementation of multi_scale_cross_entropy2d

the function was calling input.device when input is a python tuple. this should fix the error reported in https://github.com/meetshah1995/pytorch-semseg/issues/161