### PR TITLE
forwarding key:value arguments to the data_loader

### DIFF
--- a/configs/fcn8s_pascal.yml
+++ b/configs/fcn8s_pascal.yml
@@ -6,8 +6,8 @@ data:
     val_split: val
     img_rows: 'same'
     img_cols: 'same'
-    path: /private/home/meetshah/datasets/VOC/060817/VOCdevkit/VOC2012/
-    sbd_path: /private/home/meetshah/datasets/VOC/benchmark_RELEASE/
+    path: /opt/fix/Datasets/VOCdevkit/VOC2012/
+    sbd_path: /opt/fix/Datasets/benchmark_RELEASE/
 training:
     train_iters: 300000
     batch_size: 1

--- a/configs/fcn8s_pascal.yml
+++ b/configs/fcn8s_pascal.yml
@@ -6,8 +6,8 @@ data:
     val_split: val
     img_rows: 'same'
     img_cols: 'same'
-    path: /opt/fix/Datasets/VOCdevkit/VOC2012/
-    sbd_path: /opt/fix/Datasets/benchmark_RELEASE/
+    path: /private/home/meetshah/datasets/VOC/060817/VOCdevkit/VOC2012/
+    sbd_path: /private/home/meetshah/datasets/VOC/benchmark_RELEASE/
 training:
     train_iters: 300000
     batch_size: 1

--- a/train.py
+++ b/train.py
@@ -38,6 +38,14 @@ def train(cfg, writer, logger):
     data_aug = get_composed_augmentations(augmentations)
 
     # Setup Dataloader
+    dataloader_args = cfg["data"].copy()
+    dataloader_args.pop('dataset')
+    dataloader_args.pop('train_split')
+    dataloader_args.pop('val_split')
+    dataloader_args.pop('img_rows')
+    dataloader_args.pop('img_cols')
+    dataloader_args.pop('path')
+
     data_loader = get_loader(cfg["data"]["dataset"])
     data_path = cfg["data"]["path"]
 
@@ -47,6 +55,7 @@ def train(cfg, writer, logger):
         split=cfg["data"]["train_split"],
         img_size=(cfg["data"]["img_rows"], cfg["data"]["img_cols"]),
         augmentations=data_aug,
+	**dataloader_args
     )
 
     v_loader = data_loader(
@@ -54,6 +63,7 @@ def train(cfg, writer, logger):
         is_transform=True,
         split=cfg["data"]["val_split"],
         img_size=(cfg["data"]["img_rows"], cfg["data"]["img_cols"]),
+	**dataloader_args
     )
 
     n_classes = t_loader.n_classes
@@ -61,7 +71,7 @@ def train(cfg, writer, logger):
         t_loader,
         batch_size=cfg["training"]["batch_size"],
         num_workers=cfg["training"]["n_workers"],
-        shuffle=True,
+        shuffle=True
     )
 
     valloader = data.DataLoader(

--- a/train.py
+++ b/train.py
@@ -38,15 +38,6 @@ def train(cfg, writer, logger):
     data_aug = get_composed_augmentations(augmentations)
 
     # Setup Dataloader
-    dataloader_args = cfg["data"].copy()
-    dataloader_args.pop('dataset')
-    dataloader_args.pop('train_split')
-    dataloader_args.pop('val_split')
-    dataloader_args.pop('img_rows')
-    dataloader_args.pop('img_cols')
-    dataloader_args.pop('path')
-
-
     data_loader = get_loader(cfg["data"]["dataset"])
     data_path = cfg["data"]["path"]
 
@@ -56,7 +47,6 @@ def train(cfg, writer, logger):
         split=cfg["data"]["train_split"],
         img_size=(cfg["data"]["img_rows"], cfg["data"]["img_cols"]),
         augmentations=data_aug,
-        **dataloader_args
     )
 
     v_loader = data_loader(
@@ -64,7 +54,6 @@ def train(cfg, writer, logger):
         is_transform=True,
         split=cfg["data"]["val_split"],
         img_size=(cfg["data"]["img_rows"], cfg["data"]["img_cols"]),
-        **dataloader_args
     )
 
     n_classes = t_loader.n_classes
@@ -72,7 +61,7 @@ def train(cfg, writer, logger):
         t_loader,
         batch_size=cfg["training"]["batch_size"],
         num_workers=cfg["training"]["n_workers"],
-        shuffle=True
+        shuffle=True,
     )
 
     valloader = data.DataLoader(

--- a/train.py
+++ b/train.py
@@ -38,6 +38,15 @@ def train(cfg, writer, logger):
     data_aug = get_composed_augmentations(augmentations)
 
     # Setup Dataloader
+    dataloader_args = cfg["data"].copy()
+    dataloader_args.pop('dataset')
+    dataloader_args.pop('train_split')
+    dataloader_args.pop('val_split')
+    dataloader_args.pop('img_rows')
+    dataloader_args.pop('img_cols')
+    dataloader_args.pop('path')
+
+
     data_loader = get_loader(cfg["data"]["dataset"])
     data_path = cfg["data"]["path"]
 
@@ -47,6 +56,7 @@ def train(cfg, writer, logger):
         split=cfg["data"]["train_split"],
         img_size=(cfg["data"]["img_rows"], cfg["data"]["img_cols"]),
         augmentations=data_aug,
+        **dataloader_args
     )
 
     v_loader = data_loader(
@@ -54,6 +64,7 @@ def train(cfg, writer, logger):
         is_transform=True,
         split=cfg["data"]["val_split"],
         img_size=(cfg["data"]["img_rows"], cfg["data"]["img_cols"]),
+        **dataloader_args
     )
 
     n_classes = t_loader.n_classes
@@ -61,7 +72,7 @@ def train(cfg, writer, logger):
         t_loader,
         batch_size=cfg["training"]["batch_size"],
         num_workers=cfg["training"]["n_workers"],
-        shuffle=True,
+        shuffle=True
     )
 
     valloader = data.DataLoader(


### PR DESCRIPTION
This is a proposition to solve issue #188 

When training on pascal VOC, even if sbd_path is provided in the config, it does not get forwarded to the constructor of pascalVOCLoader.